### PR TITLE
Modified download data notebook to reflect that TSCC is still down

### DIFF
--- a/Module_2/Notebooks/02_Download_Data.ipynb
+++ b/Module_2/Notebooks/02_Download_Data.ipynb
@@ -1,113 +1,109 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Download fastq files from the web"
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Downloading data from ENCODE\n",
-        "\n",
-        "This is how you would download data from the [ENCODE](https://www.encodeproject.org/) website. There are many different experiments and datasets available here. You can download both raw and fully processed data. Let's take a look at HepG2 cell line conditions:\n",
-        "- knockdown of TARDBP (or TDP-43) data [here](https://www.encodeproject.org/experiments/ENCSR527QNC/)\n",
-        "- control [here](https://www.encodeproject.org/experiments/ENCSR264TUE/) \n",
-        "\n",
-        "Let's find the fastq files now. \n",
-        "- Go down to the \"Files\" section\n",
-        "- Click on the \"File details\" tab \n",
-        "- Under the \"Raw sequencing data\" we can find our fastq files \n",
-        "- When you have found the link to the fastq files, right click on the download link and select \"Copy Link Address\". \n",
-        "\n",
-        "### Example:\n",
-        "    wget https://www.encodeproject.org/files/ENCFF682WVW/@@download/ENCFF682WVW.fastq.gz\n",
-        "\n",
-        "\n",
-        "### Notes:\n",
-        "\n",
-        "- ENCODE also has processed data files that have already been aligned (to different genome builds GRCh38 V28 or hg19) and quantified. In order to run the entire pipeline, we only want the raw reads stored in fastq.  \n",
-        "\n",
-        "- *Keep in mind* that this data is paired-end, so there are two reads per dataset (R1 and R2). So you will need to download two files per sample. \n",
-        "    \n"
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Using data already uploaded to the TSCC:\n",
-        "\n",
-        "To avoid backlog on the login node, for the purposes of this class we will be using pre-loaded data on the TSCC.\n",
-        "\n",
-        "fastq files are located in this folder:\n",
-        "```\n",
-        "/biom262_2019/Module_1/raw_data/\n",
-        "```\n",
-        "\n",
-        "Here you will find fastq files named:\n",
-        "\n",
-        "```\n",
-        "NT_cont_shRNA_HepG2_Rep1_R1.fastq.gz\n",
-        "NT_cont_shRNA_HepG2_Rep1_R2.fastq.gz\n",
-        "NT_cont_shRNA_HepG2_Rep2_R1.fastq.gz\n",
-        "NT_cont_shRNA_HepG2_Rep2_R2.fastq.gz\n",
-        "\n",
-        "\n",
-        "TARDBP_shRNA_HepG2_Rep1_R1.fastq.gz   \n",
-        "TARDBP_shRNA_HepG2_Rep1_R2.fastq.gz\n",
-        "TARDBP_shRNA_HepG2_Rep2_R1.fastq.gz\n",
-        "TARDBP_shRNA_HepG2_Rep2_R2.fastq.gz\n",
-        "```"
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "We're using an ENCODE dataset because they are well standardized and monitored for quality, easy to access, and useful for pairwise comparison. However, if you would like to find out how to download other publicly available data, such as datasets available on the [Gene Expression Omnibus](\"https://www.ncbi.nlm.nih.gov/geo/\") (GEO), check out this [notebook](\"https://github.com/biom262/biom262-2018/blob/master/Module1_Unix_RNASeq/Tutorials/Download_data_from_GEO.ipynb\") in the Tutorials section."
-      ],
-      "metadata": {
-        "collapsed": true
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "outputs": [],
-      "execution_count": null,
-      "metadata": {
-        "collapsed": true
-      }
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "name": "python3",
-      "language": "python",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.6.7",
-      "mimetype": "text/x-python",
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "pygments_lexer": "ipython3",
-      "nbconvert_exporter": "python",
-      "file_extension": ".py"
-    },
-    "kernel_info": {
-      "name": "python3"
-    },
-    "nteract": {
-      "version": "0.15.0"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Download fastq files from the web"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 1
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Downloading data from ENCODE\n",
+    "\n",
+    "This is how you would download data from the [ENCODE](https://www.encodeproject.org/) website. There are many different experiments and datasets available here. You can download both raw and fully processed data. Let's take a look at HepG2 cell line conditions:\n",
+    "- knockdown of TARDBP (or TDP-43) data [here](https://www.encodeproject.org/experiments/ENCSR527QNC/)\n",
+    "- control [here](https://www.encodeproject.org/experiments/ENCSR264TUE/) \n",
+    "\n",
+    "Let's find the fastq files now. \n",
+    "- Go down to the \"Files\" section\n",
+    "- Click on the \"File details\" tab \n",
+    "- Under the \"Raw sequencing data\" we can find our fastq files \n",
+    "- When you have found the link to the fastq files, right click on the download link and select \"Copy Link Address\". \n",
+    "\n",
+    "### Example:\n",
+    "\n",
+    "```\n",
+    "$ wget https://www.encodeproject.org/files/ENCFF682WVW/@@download/ENCFF682WVW.fastq.gz\n",
+    "```\n",
+    "\n",
+    "### Notes:\n",
+    "\n",
+    "- ENCODE also has processed data files that have already been aligned (to different genome builds GRCh38 V28 or hg19) and quantified. In order to run the entire pipeline, we only want the raw reads stored in fastq.  \n",
+    "\n",
+    "- *Keep in mind* that this data is paired-end, so there are two reads per dataset (R1 and R2). So you will need to download two files per sample. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using data already uploaded to the GitHub\n",
+    "\n",
+    "If TSCC were online this week, then it would cause a backlog on the login node if all of us were to download ENCODE data using `wget`! For the purposes of this class, we'll be using pre-loaded data that we've uploaded to GitHub for this week.\n",
+    "\n",
+    "The FASTQ files for this \n",
+    "\n",
+    "fastq files are located in this folder:\n",
+    "\n",
+    "```\n",
+    "/cmm262-2020/Module_2/Data/\n",
+    "```\n",
+    "\n",
+    "Here you will find fastq file named:\n",
+    "\n",
+    "```\n",
+    "sample.fastq.gz\n",
+    "```\n",
+    "\n",
+    "This is a subsampling of the ENCODE dataset that we featured in the previous section. \n",
+    "\n",
+    "### Extra Practice for `wget`\n",
+    "\n",
+    "If you're interested, you can download this data to your Jupyter notebook by clicking on the fastq file on GitHub, and then right-clicking the `Download` button. This will give you a link that you can then use for the `wget` command:\n",
+    "\n",
+    "```\n",
+    "$ wget https://github.com/biom262/cmm262-2020/raw/master/Module_2/Data/sample.fastq.gz\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Why ENCODE?\n",
+    "\n",
+    "We're using an ENCODE dataset because they are well standardized and monitored for quality, easy to access, and useful for pairwise comparison. However, if you would like to find out how to download other publicly available data, such as datasets available on the [Gene Expression Omnibus](\"https://www.ncbi.nlm.nih.gov/geo/\") (GEO), check out this [notebook](\"https://github.com/biom262/biom262-2018/blob/master/Module1_Unix_RNASeq/Tutorials/Download_data_from_GEO.ipynb\") in the Tutorials section."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernel_info": {
+   "name": "python3"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  },
+  "nteract": {
+   "version": "0.15.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Since TSCC is still down, modified the notebook to include proper paths to the FASTQ file in the GitHub repository for the class. Also, added an additional exercise to practice wget from Jupyter Notebooks of this file on the GitHub! 