### PR TITLE
Extracredit - found typo

### DIFF
--- a/Module_5/Notebooks/cmm262-2020-Module5-workshop1.ipynb
+++ b/Module_5/Notebooks/cmm262-2020-Module5-workshop1.ipynb
@@ -186,7 +186,7 @@
         "To create a tag directory for the Oct4 experiment, run the following command with recommended options:\n",
         "\n",
         "```\n",
-        "makeTagDirectory ~/workshop-2.4/tag_dirs/oct4-esc -genome mm9 -checkGC ~/workshop-2.4/aligned/oct4-esc.chr17.2m.bam\n",
+        "makeTagDirectory ~/workshop-2.4/tagdirs/oct4-esc -genome mm9 -checkGC ~/workshop-2.4/aligned/oct4-esc.chr17.2m.bam\n",
         "```\n",
         "\n",
         "The command will take several seconds to run. What it is doing is parsing through the BAM file, removing reads that do not align to a unique position in the genome, separating reads by chromosome and sorting them by position, calculating how often reads appear in the same position to estimate the clonality (i.e. PCR duplication), calculating the relative distribution of reads relative to one another to estimate the ChIP-fragment length, calculating sequence properties and GC-content of the reads and performs a simple enrichment calculation to check if the experiment looks like a ChIP-seq experiment (vs. an RNA-seq experiment).\n",


### PR DESCRIPTION
Issue Number: #27  

I found a typo in the file called "cmm262-2020-Module5-workshop1.ipynb" in Module_5 (ChIP-Seq with Professor Alon Goren).
-Line 189: tag_dirs --> tagdirs